### PR TITLE
Enable chat panel maximization, restore, close on escape and state retention across page refresh/navigation

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -1495,6 +1495,12 @@ class ChatWidget {
     this.isFirstQuestion = true;
     this.currentBingeId = null;
     this.previousQuestionSlug = null;
+    // Restore state is we are coming from a page refresh
+    if (sessionStorage) {
+      if (sessionStorage.getItem("isFirstQuestion")) this.isFirstQuestion = sessionStorage.getItem("isFirstQuestion") === "true";
+      if (sessionStorage.getItem("currentBingeId")) this.currentBingeId = sessionStorage.getItem("currentBingeId");
+      if (sessionStorage.getItem("previousQuestionSlug")) this.previousQuestionSlug = sessionStorage.getItem("previousQuestionSlug");
+    }
 
     if (!this.widgetId) {
       console.error("Widget Error: Widget ID is required");
@@ -1674,30 +1680,35 @@ class ChatWidget {
       wrapper.appendChild(button);
 
       // Add click event listener
-      button.addEventListener('click', function() {
-        // Add click effect
-        this.style.transform = 'scale(0.95)';
-        setTimeout(() => this.style.transform = 'scale(1)', 100);
+      this.addCodeBlockCopyEventListener(button);
+    });
+  }
 
-        const codeText = this.parentElement.querySelector('code').textContent;
-        navigator.clipboard.writeText(codeText).then(() => {
-          // Change button state
-          this.innerHTML = `
+  addCodeBlockCopyEventListener(button) {
+    // Add click event listener
+    button.addEventListener('click', function() {
+      // Add click effect
+      this.style.transform = 'scale(0.95)';
+      setTimeout(() => this.style.transform = 'scale(1)', 100);
+
+      const codeText = this.parentElement.querySelector('code').textContent;
+      navigator.clipboard.writeText(codeText).then(() => {
+        // Change button state
+        this.innerHTML = `
             <svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
               <polyline points='20 6 9 17 4 12'></polyline>
             </svg>
           `;
 
-          // Reset button after delay
-          setTimeout(() => {
-            this.innerHTML = `
+        // Reset button after delay
+        setTimeout(() => {
+          this.innerHTML = `
               <svg width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2'>
                 <rect x='9' y='9' width='13' height='13' rx='2' ry='2'></rect>
                 <path d='M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1'></path>
               </svg>
             `;
-          }, 1000);
-        });
+        }, 1000);
       });
     });
   }
@@ -1893,6 +1904,22 @@ class ChatWidget {
         sessionStorage.setItem("chatWidth", chatWindow.clientWidth);
       } else {
         sessionStorage.removeItem("chatWidth");
+      }
+      // Save additional state relevant to questions and binges
+      if (this.previousQuestionSlug) {
+        sessionStorage.setItem("previousQuestionSlug", this.previousQuestionSlug);
+      } else {
+        sessionStorage.removeItem("previousQuestionSlug");
+      }
+      if (this.currentBingeId) {
+        sessionStorage.setItem("currentBingeId", this.currentBingeId);
+      } else {
+        sessionStorage.removeItem("currentBingeId");
+      }
+      if (!this.isFirstQuestion) {
+        sessionStorage.setItem("isFirstQuestion", this.isFirstQuestion);
+      } else {
+        sessionStorage.removeItem("isFirstQuestion");
       }
     }
   }
@@ -2493,7 +2520,7 @@ class ChatWidget {
       }
 
       // Add buttons to the bot response
-      const buttons = createResponseButtons(botResponseElement, finalResponse);
+      const buttons = this.createResponseButtons(finalResponse);
       botResponseElement.appendChild(buttons);
 
       // Fetch and display follow-up examples
@@ -2506,15 +2533,7 @@ class ChatWidget {
 
         if (followUpExamples.length > 0) {
           const messagesContainer = this.shadow.querySelector(".chat-messages");
-          const exampleQuestionsContainer = this.createExampleQuestions(
-            followUpExamples,
-            (selectedQuestion) => {
-              const questionInput = this.shadow.getElementById("questionInput");
-              questionInput.value = selectedQuestion;
-              questionInput.dispatchEvent(new Event("input"));
-              this.submitQuestion(selectedQuestion);
-            }
-          );
+          const exampleQuestionsContainer = this.createExampleQuestions(followUpExamples);
 
           if (exampleQuestionsContainer) {
             // Remove any existing example questions
@@ -2846,6 +2865,9 @@ class ChatWidget {
     --chat-button-bg: ${this.mainColor};
   `;
 
+    // If we have loaded state following a page refresh attach the event listeners the restored chat panel's controls
+    this.addInitialStateEventListeners();
+
     // Set hover and active colors
     chatButton.style.setProperty(
       "--chat-button-hover-bg",
@@ -2939,6 +2961,37 @@ class ChatWidget {
       this.setChatPanelWidth(sessionStorage.getItem("chatWidth"));
       this.toggleChat();
     }
+  }
+
+  addInitialStateEventListeners() {
+    // Add listeners for copy response buttons
+    this.shadow.querySelectorAll(".copy-response-button").forEach((button) => {
+      const textContainerId = button.getAttribute("data-text-id");
+      let textToCopy = "";
+      if (textContainerId) {
+        const textContainerDiv = this.shadow.getElementById(textContainerId);
+        if (textContainerDiv) {
+          textToCopy = textContainerDiv.innerHTML;
+        }
+      }
+      this.addResponseButtonEventListeners(button, () => this.copyResponseText(textToCopy))
+    })
+    // Add listeners for code block copy buttons
+    this.shadow.querySelectorAll(".code-block-copy-button").forEach((button) => {
+      this.addCodeBlockCopyEventListener(button);
+    });
+    // Add listeners for example questions
+    this.shadow.querySelectorAll(".example-question").forEach((button) => {
+      const questionContainerId = button.getAttribute("data-question-id");
+      let question = "";
+      if (questionContainerId) {
+        const questionContainerDiv = this.shadow.getElementById(questionContainerId);
+        if (questionContainerDiv) {
+          question = questionContainerDiv.innerHTML;
+        }
+      }
+      this.addExampleQuestionEventListener(button, question);
+    });
   }
 
   async loadHljsTheme(themeName) {
@@ -3153,22 +3206,40 @@ class ChatWidget {
     }
   }
 
-  createExampleQuestions(questions, onQuestionClick) {
+  createExampleQuestions(questions) {
     if (!Array.isArray(questions) || questions.length === 0) return null;
 
     const container = document.createElement("div");
     container.className = "example-questions flex flex-wrap gap-2";
 
-    questions.forEach((question, index) => {
+    questions.forEach((question) => {
+      const questionUuid = this.createUuid();
+      // Create hidden container for the example question to ensure this persists page refreshes
+      const exampleQuestionContainer = document.createElement("div");
+      exampleQuestionContainer.className = 'hidden';
+      exampleQuestionContainer.id = questionUuid;
+      exampleQuestionContainer.innerHTML = question;
+      container.appendChild(exampleQuestionContainer);
+      // Create button
       const button = document.createElement("button");
       button.className = "example-question";
       button.textContent = question;
       button.setAttribute("aria-label", `Example question: ${question}`);
-      button.onclick = (e) => onQuestionClick(question, e);
+      button.setAttribute("data-question-id", questionUuid);
+      this.addExampleQuestionEventListener(button, question);
       container.appendChild(button);
     });
 
     return container;
+  }
+
+  addExampleQuestionEventListener(button, selectedQuestion) {
+    button.addEventListener("click", () => {
+      const questionInput = this.shadow.getElementById("questionInput");
+      questionInput.value = selectedQuestion;
+      questionInput.dispatchEvent(new Event("input"));
+      this.submitQuestion(selectedQuestion);
+    });
   }
 
   handleViewportHeight() {
@@ -3375,6 +3446,106 @@ class ChatWidget {
       chatButton.style.setProperty('--tooltip-left', `${leftPosition}%`);
     }
   }
+
+  addResponseButtonEventListeners(button, onClick) {
+    // Hover effect
+    button.addEventListener("onmouseover", (event) => {
+      event.target.style.transform = "translateY(-1px)";
+    });
+    button.addEventListener("onmouseout", (event) => {
+      event.target.style.transform = "translateY(0)";
+    });
+    // Click effect
+    button.addEventListener("onmousedown", (event) => {
+      event.target.style.transform = "translateY(0)";
+    });
+    button.addEventListener("onmouseup", (event) => {
+      event.target.style.transform = "translateY(-1px)";
+    });
+    button.addEventListener("click", () => {
+      // Call the original onClick handler
+      onClick();
+
+      const originalIcon = button.innerHTML;
+      // Show success state
+      button.innerHTML = this.getSuccessIcon();
+
+      // Reset after 1 second
+      setTimeout(() => {
+        button.style.backgroundColor = "inherit";
+        button.innerHTML = originalIcon;
+      }, 1000);
+    });
+  }
+
+  // Create response buttons
+  createResponseButtons(textToCopy) {
+    const buttonContainer = document.createElement("div");
+    buttonContainer.className = "response-buttons";
+    buttonContainer.style.display = "flex";
+    buttonContainer.style.gap = "12px";
+    buttonContainer.style.marginTop = "8px"; // Optional: to separate from the response
+
+    const containerUuid = this.createUuid();
+    // Add the response text to a hidden container so that we can restore it following a page refresh
+    const copyTextContainer = document.createElement("div");
+    copyTextContainer.className = 'hidden';
+    copyTextContainer.id = containerUuid;
+    copyTextContainer.innerHTML = textToCopy;
+    buttonContainer.appendChild(copyTextContainer);
+
+    const copyButton = this.createResponseButton(
+      `<path fill-rule="evenodd" clip-rule="evenodd" d="M10 0.832031H7.29572C6.07055 0.832021 5.10013 0.832013 4.34065 0.934122C3.55904 1.03921 2.9264 1.26062 2.4275 1.75953C1.92859 2.25844 1.70718 2.89107 1.60209 3.67268C1.49998 4.43216 1.49999 5.40258 1.5 6.62775V10.6654C1.5 11.9135 2.4147 12.9481 3.61034 13.1352C3.70232 13.6445 3.87835 14.0793 4.23223 14.4331C4.63351 14.8344 5.13876 15.007 5.73883 15.0877C6.31681 15.1654 7.05169 15.1654 7.96342 15.1654H10.0366C10.9483 15.1654 11.6832 15.1654 12.2612 15.0877C12.8612 15.007 13.3665 14.8344 13.7678 14.4331C14.169 14.0319 14.3416 13.5266 14.4223 12.9265C14.5 12.3486 14.5 11.6137 14.5 10.7019V7.29545C14.5 6.38372 14.5 5.64884 14.4223 5.07086C14.3416 4.47079 14.169 3.96554 13.7678 3.56427C13.4139 3.21038 12.9791 3.03435 12.4698 2.94237C12.2827 1.74673 11.2482 0.832031 10 0.832031ZM11.4196 2.84614C11.2177 2.25619 10.6584 1.83203 10 1.83203H7.33333C6.06212 1.83203 5.15901 1.83309 4.4739 1.9252C3.80317 2.01538 3.41674 2.18449 3.1346 2.46663C2.85246 2.74877 2.68335 3.1352 2.59317 3.80593C2.50106 4.49104 2.5 5.39415 2.5 6.66536V10.6654C2.5 11.3237 2.92416 11.883 3.51411 12.0849C3.49999 11.6783 3.49999 11.2185 3.5 10.7019V7.29545C3.49999 6.38372 3.49998 5.64884 3.57768 5.07086C3.65836 4.47079 3.83096 3.96554 4.23223 3.56427C4.63351 3.16299 5.13876 2.99039 5.73883 2.90971C6.31681 2.83201 7.05169 2.83202 7.96342 2.83203H10.0366C10.5531 2.83202 11.0129 2.83202 11.4196 2.84614ZM4.93934 4.27137C5.12385 4.08686 5.3829 3.96657 5.87208 3.9008C6.37565 3.83309 7.04306 3.83203 8 3.83203H10C10.9569 3.83203 11.6244 3.83309 12.1279 3.9008C12.6171 3.96657 12.8762 4.08686 13.0607 4.27137C13.2452 4.45588 13.3655 4.71493 13.4312 5.20411C13.4989 5.70768 13.5 6.37509 13.5 7.33203V10.6654C13.5 11.6223 13.4989 12.2897 13.4312 12.7933C13.3655 13.2825 13.2452 13.5415 13.0607 13.726C12.8762 13.9105 12.6171 14.0308 12.1279 14.0966C11.6244 14.1643 10.9569 14.1654 10 14.1654H8C7.04306 14.1654 6.37565 14.1643 5.87208 14.0966C5.3829 14.0308 5.12385 13.9105 4.93934 13.726C4.75483 13.5415 4.63453 13.2825 4.56877 12.7933C4.50106 12.2897 4.5 11.6223 4.5 10.6654V7.33203C4.5 6.37509 4.50106 5.70768 4.56877 5.20411C4.63453 4.71493 4.75483 4.45588 4.93934 4.27137Z" fill="var(--response-button-color)"/>`,
+      "",
+      () => this.copyResponseText(textToCopy),
+      "copy"
+    );
+    copyButton.setAttribute("data-text-id", containerUuid);
+    buttonContainer.appendChild(copyButton);
+
+    return buttonContainer;
+  }
+
+  copyResponseText(textToCopy) {
+    navigator.clipboard.writeText(textToCopy).then(() => {});
+  }
+
+  createUuid() {
+    return Math.random().toString(36).substr(2);
+  }
+
+  getSuccessIcon() {
+    return `
+    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <polyline points="20 6 9 17 4 12" stroke="var(--response-button-color)" stroke-width="2"/>
+    </svg>
+    `;
+  }
+
+  createResponseButton(icon, text, onClick, type) {
+    const button = document.createElement("button");
+    button.className = `${type}-response-button`;
+    button.style.cssText = `
+      border: none;
+      background: inherit;
+      display: flex;
+      align-items: center;
+      padding: 0;
+      cursor: pointer;
+      transition: background-color 0.2s ease, transform 0.2s ease;
+    `;
+
+    button.innerHTML = `
+    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+      ${icon}
+    </svg>
+    ${text}
+  `;
+    this.addResponseButtonEventListeners(button, onClick);
+
+    return button;
+  }
+
 }
 
 function loadScript(url) {
@@ -3419,115 +3590,3 @@ function loadScript(url) {
 // document.addEventListener("DOMContentLoaded", () => {
 //   window.chatWidget = new ChatWidget();
 // });
-
-// Function to create buttons
-function createResponseButtons(botResponseElement, textToCopy) {
-  function createButton(icon, text, onClick, type) {
-    const button = document.createElement("button");
-    button.className = `${type}-response-button`;
-    button.style.cssText = `
-      border: none;
-      background: inherit;
-      display: flex;
-      align-items: center;
-      padding: 0;
-      cursor: pointer;
-      transition: background-color 0.2s ease, transform 0.2s ease;
-    `;
-
-    const originalIcon = `
-    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
-      ${icon}
-    </svg>
-    ${text}
-  `;
-
-    const successIcon = `
-    <svg width="16" height="16" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
-      <polyline points="20 6 9 17 4 12" stroke="var(--response-button-color)" stroke-width="2"/>
-    </svg>
-  `;
-
-    button.innerHTML = originalIcon;
-
-    // Hover effect
-    button.onmouseover = () => {
-      button.style.transform = "translateY(-1px)";
-    };
-
-    button.onmouseout = () => {
-      button.style.transform = "translateY(0)";
-    };
-
-    // Click effect
-    button.onmousedown = () => {
-      button.style.transform = "translateY(0)";
-    };
-
-    button.onmouseup = () => {
-      button.style.transform = "translateY(-1px)";
-    };
-
-    button.onclick = async (e) => {
-      // Call the original onClick handler
-      await onClick(e);
-
-      // Show success state
-      button.innerHTML = successIcon;
-
-      // Reset after 1 second
-      setTimeout(() => {
-        button.style.backgroundColor = "inherit";
-        button.innerHTML = originalIcon;
-      }, 1000);
-    };
-    return button;
-  }
-
-  function onClickCopy() {
-    navigator.clipboard.writeText(textToCopy).then(() => {});
-  }
-
-  function onClickLike() {
-    // TODO: Implement like functionality
-    // Mock API request
-  }
-
-  function onClickDislike() {
-    // TODO: Implement dislike functionality
-    // Mock API request
-  }
-
-  const buttonContainer = document.createElement("div");
-  buttonContainer.className = "response-buttons";
-  buttonContainer.style.display = "flex";
-  buttonContainer.style.gap = "12px";
-  buttonContainer.style.marginTop = "8px"; // Optional: to separate from the response
-
-  const copyButton = createButton(
-    `<path fill-rule="evenodd" clip-rule="evenodd" d="M10 0.832031H7.29572C6.07055 0.832021 5.10013 0.832013 4.34065 0.934122C3.55904 1.03921 2.9264 1.26062 2.4275 1.75953C1.92859 2.25844 1.70718 2.89107 1.60209 3.67268C1.49998 4.43216 1.49999 5.40258 1.5 6.62775V10.6654C1.5 11.9135 2.4147 12.9481 3.61034 13.1352C3.70232 13.6445 3.87835 14.0793 4.23223 14.4331C4.63351 14.8344 5.13876 15.007 5.73883 15.0877C6.31681 15.1654 7.05169 15.1654 7.96342 15.1654H10.0366C10.9483 15.1654 11.6832 15.1654 12.2612 15.0877C12.8612 15.007 13.3665 14.8344 13.7678 14.4331C14.169 14.0319 14.3416 13.5266 14.4223 12.9265C14.5 12.3486 14.5 11.6137 14.5 10.7019V7.29545C14.5 6.38372 14.5 5.64884 14.4223 5.07086C14.3416 4.47079 14.169 3.96554 13.7678 3.56427C13.4139 3.21038 12.9791 3.03435 12.4698 2.94237C12.2827 1.74673 11.2482 0.832031 10 0.832031ZM11.4196 2.84614C11.2177 2.25619 10.6584 1.83203 10 1.83203H7.33333C6.06212 1.83203 5.15901 1.83309 4.4739 1.9252C3.80317 2.01538 3.41674 2.18449 3.1346 2.46663C2.85246 2.74877 2.68335 3.1352 2.59317 3.80593C2.50106 4.49104 2.5 5.39415 2.5 6.66536V10.6654C2.5 11.3237 2.92416 11.883 3.51411 12.0849C3.49999 11.6783 3.49999 11.2185 3.5 10.7019V7.29545C3.49999 6.38372 3.49998 5.64884 3.57768 5.07086C3.65836 4.47079 3.83096 3.96554 4.23223 3.56427C4.63351 3.16299 5.13876 2.99039 5.73883 2.90971C6.31681 2.83201 7.05169 2.83202 7.96342 2.83203H10.0366C10.5531 2.83202 11.0129 2.83202 11.4196 2.84614ZM4.93934 4.27137C5.12385 4.08686 5.3829 3.96657 5.87208 3.9008C6.37565 3.83309 7.04306 3.83203 8 3.83203H10C10.9569 3.83203 11.6244 3.83309 12.1279 3.9008C12.6171 3.96657 12.8762 4.08686 13.0607 4.27137C13.2452 4.45588 13.3655 4.71493 13.4312 5.20411C13.4989 5.70768 13.5 6.37509 13.5 7.33203V10.6654C13.5 11.6223 13.4989 12.2897 13.4312 12.7933C13.3655 13.2825 13.2452 13.5415 13.0607 13.726C12.8762 13.9105 12.6171 14.0308 12.1279 14.0966C11.6244 14.1643 10.9569 14.1654 10 14.1654H8C7.04306 14.1654 6.37565 14.1643 5.87208 14.0966C5.3829 14.0308 5.12385 13.9105 4.93934 13.726C4.75483 13.5415 4.63453 13.2825 4.56877 12.7933C4.50106 12.2897 4.5 11.6223 4.5 10.6654V7.33203C4.5 6.37509 4.50106 5.70768 4.56877 5.20411C4.63453 4.71493 4.75483 4.45588 4.93934 4.27137Z" fill="var(--response-button-color)"/>`,
-    "",
-    onClickCopy,
-    "copy"
-  );
-
-  // const likeButton = createButton(
-  //   `<path fill-rule="evenodd" clip-rule="evenodd" d="M8.29214 1.85097C8.19543 1.81991 8.08968 1.82744 7.99985 1.87072C7.9015 1.91812 7.8365 2.00083 7.81316 2.09084L7.49602 3.31341C7.38511 3.74096 7.22363 4.15335 7.01566 4.54269C6.69277 5.14715 6.20422 5.61203 5.75098 6.0026L4.79182 6.82912C4.64317 6.95722 4.56493 7.14925 4.58188 7.34523L5.12332 13.607C5.15068 13.9233 5.41496 14.1654 5.7309 14.1654H8.82998C10.9209 14.1654 12.6825 12.7105 13.0204 10.7568L13.4908 8.03695C13.5555 7.66263 13.2676 7.3215 12.8899 7.3215H9.43579C8.78438 7.3215 8.28959 6.73707 8.39476 6.09517L8.83655 3.3988C8.89706 3.02945 8.87978 2.65152 8.78581 2.28926C8.73812 2.10542 8.59306 1.94764 8.38878 1.88202L8.29214 1.85097L8.44506 1.37493L8.29214 1.85097ZM7.56575 0.969861C7.88748 0.814829 8.25817 0.789727 8.59799 0.898894L8.69464 0.929941L8.54171 1.40598L8.69464 0.929941C9.21264 1.09635 9.6168 1.51016 9.75377 2.03817C9.8827 2.53521 9.90641 3.05374 9.82339 3.56049L9.38161 6.25686C9.37595 6.29137 9.40254 6.3215 9.43579 6.3215H12.8899C13.8894 6.3215 14.6463 7.22304 14.4761 8.20736L14.0058 10.9272C13.5805 13.3861 11.3808 15.1654 8.82998 15.1654H5.7309C4.89513 15.1654 4.19901 14.5255 4.12704 13.6932L3.5856 7.43137C3.541 6.91556 3.74681 6.40957 4.13903 6.07158L5.09819 5.24506C5.535 4.86865 5.90269 4.50381 6.13361 4.07152C6.30466 3.75131 6.43715 3.41274 6.52805 3.06231L6.84519 1.83974C6.94468 1.45621 7.21109 1.14076 7.56575 0.969861ZM1.97844 6.32196C2.24595 6.31042 2.47507 6.51166 2.49814 6.77842L3.14587 14.2694C3.18748 14.7506 2.80846 15.1654 2.32447 15.1654C1.86859 15.1654 1.5 14.7955 1.5 14.3405V6.8215C1.5 6.55374 1.71093 6.33351 1.97844 6.32196Z" fill="var(--response-button-color)"/>`,
-  //   "",
-  //   onClickLike,
-  //   "like"
-  // );
-
-  // const dislikeButton = createButton(
-  //   `<path fill-rule="evenodd" clip-rule="evenodd" d="M8.29214 14.149C8.19543 14.1801 8.08968 14.1726 7.99985 14.1293C7.9015 14.0819 7.8365 13.9992 7.81316 13.9092L7.49602 12.6866C7.38511 12.259 7.22363 11.8467 7.01566 11.4573C6.69277 10.8529 6.20422 10.388 5.75098 9.9974L4.79182 9.17088C4.64317 9.04278 4.56493 8.85075 4.58188 8.65477L5.12332 2.39299C5.15068 2.07665 5.41496 1.83464 5.7309 1.83464H8.82998C10.9209 1.83464 12.6825 3.28948 13.0204 5.24321L13.4908 7.96305C13.5555 8.33737 13.2676 8.6785 12.8899 8.6785H9.43579C8.78438 8.6785 8.28959 9.26293 8.39476 9.90483L8.83655 12.6012C8.89706 12.9705 8.87978 13.3485 8.78581 13.7107C8.73812 13.8946 8.59306 14.0524 8.38878 14.118L8.29214 14.149L8.44506 14.6251L8.29214 14.149ZM7.56575 15.0301C7.88748 15.1852 8.25817 15.2103 8.59799 15.1011L8.69464 15.0701L8.54171 14.594L8.69464 15.0701C9.21264 14.9036 9.6168 14.4898 9.75377 13.9618C9.8827 13.4648 9.90641 12.9463 9.82339 12.4395L9.38161 9.74314C9.37595 9.70863 9.40254 9.6785 9.43579 9.6785H12.8899C13.8894 9.6785 14.6463 8.77696 14.4761 7.79264L14.0058 5.0728C13.5805 2.61394 11.3808 0.834637 8.82998 0.834637H5.7309C4.89513 0.834637 4.19901 1.47447 4.12704 2.30685L3.5856 8.56863C3.541 9.08444 3.74681 9.59043 4.13903 9.92842L5.09819 10.7549C5.535 11.1314 5.90269 11.4962 6.13361 11.9285C6.30466 12.2487 6.43715 12.5873 6.52805 12.9377L6.84519 14.1603C6.94468 14.5438 7.21109 14.8592 7.56575 15.0301ZM1.97844 9.67804C2.24595 9.68958 2.47507 9.48834 2.49814 9.22158L3.14587 1.73056C3.18748 1.24937 2.80846 0.834637 2.32447 0.834637C1.86859 0.834637 1.5 1.20446 1.5 1.65948V9.1785C1.5 9.44626 1.71093 9.66649 1.97844 9.67804Z" fill="var(--response-button-color)"/>`,
-  //   "",
-  //   onClickDislike,
-  //   "dislike"
-  // );
-
-  buttonContainer.appendChild(copyButton);
-  // buttonContainer.appendChild(likeButton);
-  // buttonContainer.appendChild(dislikeButton);
-
-  return buttonContainer;
-}

--- a/src/widget.js
+++ b/src/widget.js
@@ -1761,11 +1761,15 @@ class ChatWidget {
     resizeHandle.classList.remove("hidden");
   }
 
+  isMobile() {
+    return window.innerWidth <= 768;
+  }
+
   toggleChat() {
     const chatWindow = this.shadow.getElementById("chatWindow");
     const wrapper = document.getElementById("gurubase-page-content-wrapper");
     const chatButton = this.shadow.querySelector(".chat-button");
-    const isMobile = window.innerWidth <= 768;
+    const isMobile = this.isMobile();
 
     if (chatWindow) {
         const isOpening = !chatWindow.classList.contains("open");
@@ -2741,6 +2745,10 @@ class ChatWidget {
     const maximizeButton = this.shadow.querySelector('#maximizeChatButton');
     if (maximizeButton) {
       maximizeButton.addEventListener('click', () => this.maximizeChat());
+      if (this.isMobile()) {
+        // No maximization on small screens
+        maximizeButton.classList.add('hidden');
+      }
     }
 
     const minimizeButton = this.shadow.querySelector('#minimizeChatButton');


### PR DESCRIPTION
Some notes on the implementation:

- Implemented the maximize, minimize (restore) and "close on escape" features.
- Replaced all three icons (maximize, minimize, close) so that they are as consistent as possible.
- Added fluid transitions to/from maximized state, also when closing the chat (this was not working perfectly before).
- Once maximized, selecting to minimize restores the panel to the previously selected size (e.g. may have changed after a drag resizing).
- Prevented drag resizing when the panel is maximized.
- For the "close on escape", covered both a document-level key press and, when the search is focused. For the latter I replaced the "keypress" event with the more consistent "keydown".
- Removed some event listener references that were apparently leftovers from previous code cleanup.