### PR TITLE
When saving the chat panel's content only consider completed exchanges

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -1896,7 +1896,18 @@ class ChatWidget {
         sessionStorage.removeItem("chatState");
       } else {
         const messagesContainer = this.shadow.querySelector(".chat-messages");
-        sessionStorage.setItem("chatState", messagesContainer.innerHTML);
+        let messagesToSave = "";
+        if (messagesContainer) {
+          // Select only completed messages
+          messagesToSave = Array.from(messagesContainer.querySelectorAll(".completed"))
+            .map(el => el.outerHTML) // Get the messages' HTML content
+            .join(""); // Convert array to string
+        }
+        if (messagesToSave.length > 0) {
+          sessionStorage.setItem("chatState", messagesToSave);
+        } else {
+          sessionStorage.removeItem("chatState");
+        }
       }
       // Save the chat panel's width to restore (if currently open and not maximized/maximizing)
       const chatWindow = this.shadow.getElementById("chatWindow");
@@ -2615,8 +2626,17 @@ class ChatWidget {
         submitButton.style.opacity = "1";
         submitButton.style.cursor = "pointer";
       }
+      // Mark the messages produced by this question/answer as completed.
+      this.markMessagesAsCompleted();
     }
     this.resetClearButton();
+  }
+
+  markMessagesAsCompleted() {
+    // Set all direct children of the chat message panel as completed to flag them as being eligible for state saving
+    this.shadow.querySelectorAll(".chat-messages > :not(.completed)").forEach((messageBlock) => {
+      messageBlock.classList.add("completed");
+    });
   }
 
   resetClearButton() {


### PR DESCRIPTION
This PR fixes the issue described in #48 by @kursataktas in [this comment](https://github.com/Gurubase/gurubase-widget/pull/48#issuecomment-2727597473).

In brief, when saving/restoring the widget's state to survive page refreshes or full page navigation, the state saving would simply copy all content from the panel, including incomplete answers, pending messages etc. When state was restored such unwanted elements would also be replicated, however with no possibility to be further updated.

This fix waits until all operations linked to an answer (response streaming, source referencing, example question loading) are completed, before flagging the newly added chat panel content as "complete" (via CSS marker class). This is then leveraged when persisting the state to include only the panel's content that is indeed "complete".

The fix for this was quite straightforward, but if you want to see it in action the updated widget is online in the [ITB docs](https://www.itb.ec.europa.eu/docs/tdl/latest/).