### PR TITLE
Hide trust score if it does not exist

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -2745,7 +2745,7 @@ class ChatWidget {
                 }
 
                 // Add trust score if it exists
-                if (data.trust_score !== undefined) {
+                if (data.trust_score !== undefined && data.trust_score !== null) {
                   const trustScoreHtml = this.createTrustScore(
                     data.trust_score
                   );
@@ -2905,7 +2905,7 @@ class ChatWidget {
           }
 
           // Add trust score last if it exists
-          if (data.trust_score !== undefined) {
+          if (data.trust_score !== undefined && data.trust_score !== null) {
             messageContent.innerHTML += this.createTrustScore(data.trust_score);
           }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of trust score display to ensure it only appears when the value is present, preventing potential issues with missing or null data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->