### PR TITLE
Add focus to input field on chat window open

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -3034,6 +3034,7 @@ class ChatWidget {
               chatWindow.classList.add("open");
               document.body.classList.add("widget-open");
               chatButton.style.display = 'none';
+
             } else {
             chatWindow.style.display = "flex";
             
@@ -3045,6 +3046,14 @@ class ChatWidget {
             document.body.classList.add("widget-open");
             chatButton.style.display = 'none';
             }
+
+            // Focus on the input field when opening floating window
+            chatWindow.addEventListener("transitionend", () => {
+              const questionInput = this.shadow.getElementById("questionInput");
+              if (questionInput) {
+                questionInput.focus();
+              }
+            }, { once: true });            
 
             // Scroll to the end of the current messages
             const messagesContainer = this.shadow.querySelector(".chat-messages");


### PR DESCRIPTION
Focus to input text when widget is opened

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The chat input field now automatically focuses when the chat window opens, so you can start typing immediately without clicking.
  * This behavior applies to both floating and embedded chat windows and triggers once per open event.
* **Other**
  * No changes to settings or public APIs.
  * Existing workflows remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->