### PR TITLE
Improve error message handling in ChatWidget to conditionally prepend…

### DIFF
--- a/src/widget.js
+++ b/src/widget.js
@@ -3469,9 +3469,9 @@ class ChatWidget {
         try {
           const errorData = await response.json();
           if (errorData.msg) {
-            errorMessage = this.t('errorPrefix') + errorData.msg;
+            errorMessage = errorData.not_error ? errorData.msg : this.t('errorPrefix') + errorData.msg;
           } else if (errorData.error) {
-            errorMessage = this.t('errorPrefix') + errorData.error;
+            errorMessage = errorData.not_error ? errorData.error : this.t('errorPrefix') + errorData.error;
           }
         } catch (error) {
           console.error("error", error);


### PR DESCRIPTION
… error prefix based on 'not_error' flag

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Error messages now omit the localized prefix when the response marks a message as not an error, preventing confusing or redundant text.
  * Preserves existing behavior for genuine errors with clear, prefixed messaging.
  * Improves readability across locales without altering the overall error-handling flow or other functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->